### PR TITLE
Reset progress to 0 when an error occurs

### DIFF
--- a/lib/projects/ngx-sse-client/src/lib/sse-client.service.ts
+++ b/lib/projects/ngx-sse-client/src/lib/sse-client.service.ts
@@ -90,6 +90,11 @@ export class SseClient {
   }
 
   private parseStreamEvent(event: HttpEvent<string>, observer: Subscriber<string>): void {
+    if (event.type === HttpEventType.Sent) {
+      this.progress = 0;
+      return;
+    }
+
     if (event.type === HttpEventType.DownloadProgress) {
       this.onStreamProgress((event as HttpDownloadProgressEvent).partialText, observer);
       return;


### PR DESCRIPTION
When there is an expected error and the retry pipe is triggered, the progress is not reset to zero. This will not parse the stream event correctly once the retry was successful.