### PR TITLE
bug: server response ends with non descript error

### DIFF
--- a/lib/projects/ngx-sse-client/src/lib/sse-client-subscriber.ts
+++ b/lib/projects/ngx-sse-client/src/lib/sse-client-subscriber.ts
@@ -81,7 +81,12 @@ export class SseClientSubscriber {
     this.chunk = '';
     this.progress = 0;
 
-    this.dispatchStreamData(this.errorEvent(), observer);
+    if (this.sseOptions.keepAlive) {
+      const message = `Server response ended, will reconnect in ${this.sseOptions.reconnectionDelay}ms`;
+      this.dispatchStreamData(this.errorEvent({ status: 1, message }), observer);
+    } else {
+      observer.complete();
+    }
   }
 
   private parseEventData(part: string, observer: Subscriber<string>) {

--- a/lib/projects/sample/src/app/app.component.css
+++ b/lib/projects/sample/src/app/app.component.css
@@ -5,7 +5,9 @@ small {
 .events {
   display: flex;
   justify-content: space-between;
-  max-width: 1200px;
+  font-family: monospace;
+  max-width: 1800px;
+  padding-right: 10px;
 }
 
 .buttons {

--- a/lib/projects/sample/src/app/app.component.html
+++ b/lib/projects/sample/src/app/app.component.html
@@ -7,6 +7,11 @@
   </div>
 
   <div class="event">
+    <h1>SSE Events <small>(using <code>ngx-sse-client</code> with <code>keepAlive: false</code>):</small></h1>
+    <div *ngFor="let event of sseEventsWithoutKeepalive">{{ event }}</div>
+  </div>
+
+  <div class="event">
     <h1>SOURCE Events <small>(not compatible with IE):</small></h1>
     <div *ngFor="let event of sourceEvents">{{ event }}</div>
   </div>

--- a/lib/projects/sample/src/app/app.component.ts
+++ b/lib/projects/sample/src/app/app.component.ts
@@ -14,16 +14,44 @@ export class AppComponent {
   private apiBaseUrl = environment?.apiBaseUrl || '';
 
   public sseEvents: string[] = [];
+  public sseEventsWithoutKeepalive: string[] = [];
   public sourceEvents: string[] = [];
 
   constructor(private httpClient: HttpClient, private sseClient: SseClient) {
-    this.sseClient.stream(`${this.apiBaseUrl}/subscribe`).subscribe((e) => {
+    this.sseClient.stream(`${this.apiBaseUrl}/subscribe`, { keepAlive: true }).subscribe({
+      next:(e) => {
       if (e.type === 'error') {
         const event = e as SseErrorEvent;
         this.sseEvents.push(`ERROR: ${event.message}, STATUS: ${event.status}, STATUS TEXT: ${event.statusText}`);
       } else {
         const data = (e as MessageEvent).data;
-        this.sseEvents.push(data);
+          this.sseEvents.push(data);
+        }
+      },
+      error: (e) => {
+        console.error(e);
+      },
+      complete: () => {
+        this.sseEvents.push('COMPLETE - this should never happen');
+      }
+    });
+
+
+    this.sseClient.stream(`${this.apiBaseUrl}/subscribe`, { keepAlive: false }).subscribe({
+      next:(e) => {
+      if (e.type === 'error') {
+        const event = e as SseErrorEvent;
+        this.sseEventsWithoutKeepalive.push(`ERROR: ${event.message}, STATUS: ${event.status}, STATUS TEXT: ${event.statusText}`);
+      } else {
+        const data = (e as MessageEvent).data;
+          this.sseEventsWithoutKeepalive.push(data);
+        }
+      },
+      error: (e) => {
+        console.error(e);
+      },
+      complete: () => {
+        this.sseEventsWithoutKeepalive.push('COMPLETE');
       }
     });
 

--- a/lib/projects/sample/src/app/app.component.ts
+++ b/lib/projects/sample/src/app/app.component.ts
@@ -18,7 +18,7 @@ export class AppComponent {
   public sourceEvents: string[] = [];
 
   constructor(private httpClient: HttpClient, private sseClient: SseClient) {
-    this.sseClient.stream(`${this.apiBaseUrl}/subscribe`, { keepAlive: true }).subscribe({
+    this.sseClient.stream(`${this.apiBaseUrl}/subscribe`).subscribe({
       next:(e) => {
       if (e.type === 'error') {
         const event = e as SseErrorEvent;


### PR DESCRIPTION
# Problem
When the stream ends purposefully by the server ( `response.end()` ) a non descript error is sent to the subscriber.

## Proposed Fix
Depending on the mode of the `keepAlive` flag the observable will either dispatch a friendly error message, or will complete() immediately.

## UI Testbed Changes
There is now a 3rd column for displaying SEE events with `keepAlive=false`
![Screenshot from 2025-03-05 12-59-44](https://github.com/user-attachments/assets/df4090c8-5285-4968-b2b3-740e8c197b72)

Notes:
- fixes #6 
